### PR TITLE
Enable the automatic unit conversion for the Forecast.io service

### DIFF
--- a/AFWeather.m
+++ b/AFWeather.m
@@ -157,7 +157,7 @@
                 break;
                 
             case AFWeatherAPIForecast:
-                request = [NSURLRequest requestWithURL:[NSURL URLWithString:[_baseURL stringByAppendingString:[NSString stringWithFormat:@"/%@,%@",[[lat stringByReplacingOccurrencesOfString:@"," withString:@"."] encodeForURLWithEncoding:NSUTF8StringEncoding],[[lon stringByReplacingOccurrencesOfString:@"," withString:@"."] encodeForURLWithEncoding:NSUTF8StringEncoding]]]]];
+                request = [NSURLRequest requestWithURL:[NSURL URLWithString:[_baseURL stringByAppendingString:[NSString stringWithFormat:@"/%@,%@?units=auto",[[lat stringByReplacingOccurrencesOfString:@"," withString:@"."] encodeForURLWithEncoding:NSUTF8StringEncoding],[[lon stringByReplacingOccurrencesOfString:@"," withString:@"."] encodeForURLWithEncoding:NSUTF8StringEncoding]]]]];
                 break;
                 
             case AFWeatherAPITest:


### PR DESCRIPTION
Hi! I've adjusted the URL that AFWeather uses to communicate with the Forecast.io service in such a way that numeric values are converted to proper units based on geographical location of the queried location. I would very much appreciate if you could get this little change into the main repository. Thanks a lot!
